### PR TITLE
feat: add Dota 2 dashboard and update font/docker config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,60 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+npm run dev      # Start dev server with Turbopack
+npm run build    # Production build
+npm run lint     # ESLint check
+npm run start    # Start production server
+```
+
+No test runner is configured — CI only runs `lint` and `build` via `.github/workflows/test.yml`.
+
+**Docker (development):**
+```bash
+docker-compose up   # Starts frontend on port 3000
+```
+
+## Architecture
+
+Next.js 15 App Router portfolio site with internationalization, dark mode, and an external blog API.
+
+### Key patterns
+
+- **Pages are thin** — `src/app/**/page.tsx` files just render a single component from `src/components/pages/`.
+- **Logic lives in hooks** — client-side data fetching and form state use custom `use-*.ts` hooks co-located with their component.
+- **Translations** — `next-intl` with locale stored in a `NEXT_LOCALE` cookie. Locale config: `src/i18n/config.ts` (locales: `pt-br`, `en`). Message files: `src/messages/{locale}.json`. Access via `useTranslations('components.pages.home.contact_section')` — the key path mirrors the component path.
+- **Theme** — dark/light mode managed by `ThemeContext` in `src/contexts/ThemeProvider.tsx`, persisted in `localStorage`.
+- **UI components** — shadcn/ui components live in `src/components/ui/`. Project-specific UI (Navbar, Footer, DarkMode, LocaleSwitcher) also in `src/components/ui/`.
+- **Utility** — `cn()` helper in `src/lib/utils.ts` wraps `clsx` + `tailwind-merge`.
+
+### Pages
+
+| Route | Description |
+|---|---|
+| `/` | Home page: Header, About, Education, Work Experience, Projects, Contact |
+| `/brain` | Blog listing — fetches posts from external API (`NEXT_PUBLIC_API_URL`) |
+| `/brain/post/[post_id]` | Individual blog post with comments, likes, save, and share |
+| `/api/contact/me` | POST — sends email via nodemailer with Cloudflare Turnstile CAPTCHA verification |
+| `/api/health` | Health check endpoint |
+| `/sitemap.xml` | Dynamic sitemap |
+| `/robots.ts` | Robots config |
+| `/llms.txt` and `/llms-en.txt` | LLM-readable content about the portfolio owner |
+
+### Environment variables
+
+| Variable | Purpose |
+|---|---|
+| `NEXT_PUBLIC_API_URL` | External API base URL for Brain (blog) section |
+| `NEXT_PUBLIC_SITE_URL` | Public site URL (default: `https://matheusmendes.dev`) |
+| `NEXT_PUBLIC_GA_ID` | Google Analytics ID |
+| `NEXT_PUBLIC_CLOUDFLARE_SITE_KEY` | Cloudflare Turnstile site key (contact form) |
+| `CLOUDFLARE_TURNSTILE_SECRET` | Cloudflare Turnstile secret (server-side) |
+| `SMTP_HOST` / `SMTP_PORT` / `SMTP_USER` / `SMTP_PASSWORD` | Email sending credentials |
+
+### Build output
+
+`next.config.ts` uses `output: "standalone"` for Docker deployment.

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,6 +1,6 @@
-FROM node:20.3.1-alpine
+FROM node:20.3.1-slim
 
-RUN apk -U upgrade && apk add --no-cache curl git
+RUN apt-get update && apt-get install -y --no-install-recommends curl git && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt/app
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,4 +23,4 @@ services:
 
 networks:
   frontend-network:
-    external: true
+    external: false

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -81,6 +81,7 @@
     }
     body {
       @apply bg-background text-foreground;
+      font-family: var(--font-roboto), sans-serif;
     }
   }
   

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,14 +6,12 @@ import { GoogleAnalytics } from '@next/third-parties/google';
 import type { Metadata } from 'next';
 import { NextIntlClientProvider } from 'next-intl';
 import { getLocale, getMessages } from 'next-intl/server';
-import { Geist, Geist_Mono } from 'next/font/google';
+import { Roboto } from 'next/font/google';
 import { twJoin } from 'tailwind-merge';
 import CustomDocument from './CustomDocument';
 import './globals.css';
 
-const geistSans = Geist({ variable: '--font-geist-sans', subsets: ['latin'] });
-
-const geistMono = Geist_Mono({ variable: '--font-geist-mono', subsets: ['latin'] });
+const roboto = Roboto({ variable: '--font-roboto', subsets: ['latin'], weight: ['400', '500', '700'] });
 
 export const metadata: Metadata = {
   icons: { icon: '/images/profile.png' },
@@ -29,7 +27,7 @@ export default async function RootLayout({ children }: Readonly<{ children: Reac
   return (
     <ThemeProvider>
       <CustomDocument locale={locale}>
-        <body className={twJoin(`${geistSans.variable} ${geistMono.variable}`)}>
+        <body className={twJoin(roboto.variable)}>
           <NextIntlClientProvider messages={messages}>
             <Navbar />
             <Toaster />

--- a/src/app/mydota/page.tsx
+++ b/src/app/mydota/page.tsx
@@ -1,0 +1,9 @@
+import MyDotaPage from '@/components/pages/my-dota/MyDotaPage';
+
+const Page = () => {
+  return (
+    <MyDotaPage />
+  );
+};
+
+export default Page;

--- a/src/components/pages/home/ContactSection.tsx
+++ b/src/components/pages/home/ContactSection.tsx
@@ -10,7 +10,7 @@ import {
   DrawerTrigger,
 } from '@/components/ui/drawer';
 import { Turnstile } from '@marsidev/react-turnstile';
-import { Brain, Github, Linkedin, Mail } from 'lucide-react';
+import { Brain, Github, Linkedin, Mail, Swords } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import Link from 'next/link';
 import { twJoin } from 'tailwind-merge';
@@ -37,6 +37,13 @@ const ContactSection = () => {
         className="transition-transform hover:scale-150 hover:text-black dark:hover:text-gray-200"
       >
         <Linkedin size={20} />
+      </Link>
+
+      <Link
+        href="/mydota"
+        className="transition-transform hover:scale-150 hover:text-black dark:hover:text-gray-200"
+      >
+        <Swords size={20} />
       </Link>
       <Drawer open={isOpen} onOpenChange={setIsOpen}>
         <DrawerTrigger asChild>

--- a/src/components/pages/my-dota/MatchDetail.tsx
+++ b/src/components/pages/my-dota/MatchDetail.tsx
@@ -1,0 +1,221 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+import { ExternalLink, Shield, Sword } from 'lucide-react';
+import Image from 'next/image';
+import { useDotaMatch, type MatchPlayerDto } from './use-dota-match';
+import { type HeroInfo } from './use-dota-heroes';
+
+const GAME_MODES: Record<number, string> = {
+  1: 'All Pick',
+  2: 'Captain\'s Mode',
+  3: 'Random Draft',
+  4: 'Single Draft',
+  5: 'All Random',
+  16: 'Captain\'s Draft',
+  22: 'All Pick Ranked',
+  23: 'Turbo',
+};
+
+function formatDuration(seconds: number) {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
+function formatDate(unix: number) {
+  return new Date(unix * 1000).toLocaleDateString('pt-BR', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function formatNumber(n: number) {
+  return n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n);
+}
+
+const PlayerRow = ({
+  player,
+  isMe,
+  hero,
+}: {
+  player: MatchPlayerDto;
+  isMe: boolean;
+  hero: HeroInfo | undefined;
+}) => (
+  <tr className={cn('border-b border-gray-100 text-xs dark:border-gray-800', isMe && 'bg-blue-500/10')}>
+    <td className="py-1.5 pr-2">
+      <div className="flex items-center gap-1.5">
+        {hero?.icon && (
+          <Image
+            src={hero.icon}
+            width={20}
+            height={20}
+            alt={hero.name}
+            className="shrink-0 rounded-sm"
+            unoptimized
+          />
+        )}
+        <div>
+          <span className={cn('block truncate font-medium dark:text-gray-200', isMe && 'text-blue-400')}>
+            {hero?.name ?? `Hero #${player.hero_id}`}
+            {isMe && <span className="ml-1 text-[10px] text-blue-400">(Eu)</span>}
+          </span>
+          <span className="block truncate text-[10px] text-gray-400">{player.personaname ?? 'Anônimo'}</span>
+        </div>
+      </div>
+    </td>
+    <td className="px-1 text-center dark:text-gray-300">
+      {player.kills}/{player.deaths}/{player.assists}
+    </td>
+    <td className="px-1 text-center dark:text-gray-400">{player.gold_per_min}</td>
+    <td className="px-1 text-center dark:text-gray-400">{player.xp_per_min}</td>
+    <td className="px-1 text-center dark:text-gray-400">{formatNumber(player.net_worth)}</td>
+    <td className="pl-1 text-center dark:text-gray-400">{formatNumber(player.hero_damage)}</td>
+  </tr>
+);
+
+const TeamTable = ({
+  players,
+  label,
+  color,
+  icon,
+  myAccountId,
+  heroes,
+}: {
+  players: MatchPlayerDto[];
+  label: string;
+  color: string;
+  icon: React.ReactNode;
+  myAccountId: number;
+  heroes: Map<number, HeroInfo>;
+}) => (
+  <div className="mb-4">
+    <div className={cn('mb-2 flex items-center gap-1.5 text-sm font-bold', color)}>
+      {icon}
+      {label}
+    </div>
+    <table className="w-full">
+      <thead>
+        <tr className="border-b border-gray-200 text-[10px] text-gray-500 dark:border-gray-700 dark:text-gray-500">
+          <th className="pb-1 text-left font-normal">Herói / Jogador</th>
+          <th className="pb-1 font-normal">KDA</th>
+          <th className="pb-1 font-normal">GPM</th>
+          <th className="pb-1 font-normal">XPM</th>
+          <th className="pb-1 font-normal">NW</th>
+          <th className="pb-1 font-normal">Dano</th>
+        </tr>
+      </thead>
+      <tbody>
+        {players.map((p) => (
+          <PlayerRow
+            key={p.player_slot}
+            player={p}
+            isMe={p.account_id === myAccountId}
+            hero={heroes.get(p.hero_id)}
+          />
+        ))}
+      </tbody>
+    </table>
+  </div>
+);
+
+type MatchDetailProps = {
+  matchId: number;
+  myAccountId: number;
+  isWin: boolean;
+  heroes: Map<number, HeroInfo>;
+};
+
+const MatchDetail = ({ matchId, myAccountId, isWin, heroes }: MatchDetailProps) => {
+  const { match, isLoading, error } = useDotaMatch(matchId);
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-[200px] items-center justify-center">
+        <div className="h-6 w-6 animate-spin rounded-full border-2 border-gray-400 border-t-transparent" />
+      </div>
+    );
+  }
+
+  if (error || !match) {
+    return (
+      <div className="flex min-h-[200px] items-center justify-center">
+        <p className="text-sm text-red-400">{error ?? 'Dados indisponíveis'}</p>
+      </div>
+    );
+  }
+
+  const radiantPlayers = match.players.filter((p) => p.player_slot < 128);
+  const direPlayers = match.players.filter((p) => p.player_slot >= 128);
+
+  return (
+    <div className="px-4 pb-6">
+      {/* Resultado */}
+      <div className="mb-4 flex items-center justify-between">
+        <div>
+          <p className={cn('text-2xl font-bold', isWin ? 'text-green-400' : 'text-red-400')}>
+            {isWin ? 'Vitória' : 'Derrota'}
+          </p>
+          <p className="text-xs text-gray-500 dark:text-gray-400">{formatDate(match.start_time)}</p>
+        </div>
+        <div className="text-right">
+          <p className="text-xs text-gray-500 dark:text-gray-400">{GAME_MODES[match.game_mode] ?? 'Modo desconhecido'}</p>
+          <p className="text-xs text-gray-500 dark:text-gray-400">{formatDuration(match.duration)}</p>
+        </div>
+      </div>
+
+      {/* Placar */}
+      <div className="mb-6 flex items-center justify-center gap-4 rounded-lg border
+        border-gray-200 p-3 dark:border-gray-700 dark:bg-gray-900">
+        <div className="text-center">
+          <p className={cn('text-2xl font-bold', match.radiant_win ? 'text-green-400' : 'text-gray-400')}>
+            {match.radiant_score}
+          </p>
+          <p className="text-xs text-green-500">Radiant</p>
+        </div>
+        <p className="text-gray-500">vs</p>
+        <div className="text-center">
+          <p className={cn('text-2xl font-bold', !match.radiant_win ? 'text-red-400' : 'text-gray-400')}>
+            {match.dire_score}
+          </p>
+          <p className="text-xs text-red-500">Dire</p>
+        </div>
+      </div>
+
+      {/* Times */}
+      <TeamTable
+        players={radiantPlayers}
+        label="Radiant"
+        color="text-green-400"
+        icon={<Shield size={14} />}
+        myAccountId={myAccountId}
+        heroes={heroes}
+      />
+      <TeamTable
+        players={direPlayers}
+        label="Dire"
+        color="text-red-400"
+        icon={<Sword size={14} />}
+        myAccountId={myAccountId}
+        heroes={heroes}
+      />
+
+      {/* Link OpenDota */}
+      <a
+        href={`https://www.opendota.com/matches/${matchId}`}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="flex items-center justify-center gap-1 text-xs text-gray-400 hover:text-gray-200"
+      >
+        Ver no OpenDota
+        <ExternalLink size={11} />
+      </a>
+    </div>
+  );
+};
+
+export default MatchDetail;

--- a/src/components/pages/my-dota/MyDotaPage.tsx
+++ b/src/components/pages/my-dota/MyDotaPage.tsx
@@ -1,0 +1,291 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+import {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+} from '@/components/ui/drawer';
+import { motion } from 'motion/react';
+import { ExternalLink, MapPin, Skull, Star, Swords, Trophy, X } from 'lucide-react';
+import Image from 'next/image';
+import { useState } from 'react';
+import { useDota, type DotaMatchDto } from './use-dota';
+import { useDotaHeroes, type HeroInfo } from './use-dota-heroes';
+import MatchDetail from './MatchDetail';
+
+const RANK_MEDALS: Record<number, { name: string; color: string }> = {
+  1: { name: 'Herald', color: 'text-gray-400' },
+  2: { name: 'Guardian', color: 'text-green-400' },
+  3: { name: 'Crusader', color: 'text-cyan-400' },
+  4: { name: 'Archon', color: 'text-blue-400' },
+  5: { name: 'Legend', color: 'text-purple-400' },
+  6: { name: 'Ancient', color: 'text-rose-400' },
+  7: { name: 'Divine', color: 'text-yellow-300' },
+  8: { name: 'Immortal', color: 'text-orange-400' },
+};
+
+function getRankInfo(rankTier: number | null) {
+  if (!rankTier) return null;
+  const medal = Math.floor(rankTier / 10);
+  const stars = rankTier % 10;
+  return { medal, stars, ...RANK_MEDALS[medal] };
+}
+
+function isWin(match: DotaMatchDto) {
+  const isRadiant = match.player_slot < 128;
+  return isRadiant ? match.radiant_win : !match.radiant_win;
+}
+
+function formatDuration(seconds: number) {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
+function formatDate(unix: number) {
+  return new Date(unix * 1000).toLocaleDateString('pt-BR', { day: '2-digit', month: '2-digit' });
+}
+
+const StatCard = ({ label, value }: { label: string; value: string | number }) => (
+  <div className="rounded-lg border border-gray-200 p-4 dark:border-gray-700 dark:bg-gray-900">
+    <p className="text-xs text-gray-500 dark:text-gray-400">{label}</p>
+    <p className="mt-1 text-lg font-bold dark:text-gray-100">{value}</p>
+  </div>
+);
+
+type MatchRowProps = {
+  match: DotaMatchDto;
+  index: number;
+  hero: HeroInfo | undefined;
+  onClick: (match: DotaMatchDto) => void;
+};
+
+const MatchRow = ({ match, index, hero, onClick }: MatchRowProps) => {
+  const won = isWin(match);
+  return (
+    <motion.button
+      onClick={() => onClick(match)}
+      initial={{ opacity: 0, x: -8 }}
+      animate={{ opacity: 1, x: 0 }}
+      transition={{ duration: 0.3, delay: 0.05 * index }}
+      className="flex w-full cursor-pointer items-center gap-3 rounded-lg border border-gray-200 p-3
+        text-left transition-colors hover:border-gray-400 dark:border-gray-700 dark:bg-gray-900 dark:hover:border-gray-500"
+    >
+      <span
+        className={cn(
+          'w-8 shrink-0 rounded px-1 py-0.5 text-center text-xs font-bold',
+          won ? 'bg-green-500/20 text-green-400' : 'bg-red-500/20 text-red-400'
+        )}
+      >
+        {won ? 'W' : 'L'}
+      </span>
+
+      {/* Hero icon + name */}
+      <div className="flex min-w-0 flex-1 items-center gap-2">
+        {hero?.icon ? (
+          <Image src={hero.icon} width={28} height={28} alt={hero.name} className="shrink-0 rounded-sm" unoptimized />
+        ) : (
+          <div className="h-7 w-7 shrink-0 rounded-sm bg-gray-700" />
+        )}
+        <div className="min-w-0">
+          <p className="truncate text-xs font-semibold dark:text-gray-100">{hero?.name ?? '—'}</p>
+          <div className="flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400">
+            <Swords size={10} className="text-green-400" />
+            <span>{match.kills}</span>
+            <Skull size={10} className="text-red-400" />
+            <span>{match.deaths}</span>
+            <span>/</span>
+            <span>{match.assists}</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="shrink-0 text-right">
+        <p className="text-xs text-gray-500 dark:text-gray-400">{formatDuration(match.duration)}</p>
+        <p className="text-xs text-gray-500 dark:text-gray-400">{formatDate(match.start_time)}</p>
+      </div>
+    </motion.button>
+  );
+};
+
+const MyDotaPage = () => {
+  const { player, matches, isLoading, error } = useDota();
+  const { heroes } = useDotaHeroes();
+  const [selectedMatch, setSelectedMatch] = useState<DotaMatchDto | null>(null);
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-[200px] items-center justify-center">
+        <div className="h-6 w-6 animate-spin rounded-full border-2 border-gray-400 border-t-transparent" />
+      </div>
+    );
+  }
+
+  if (error || !player) {
+    return (
+      <div className="flex min-h-[200px] items-center justify-center">
+        <p className="text-sm text-red-400">{error ?? 'Dados indisponíveis'}</p>
+      </div>
+    );
+  }
+
+  const rank = getRankInfo(player.rank_tier);
+  const { profile, mmr_estimate, leaderboard_rank } = player;
+
+  const recentMatches = matches.slice(0, 10);
+  const wins = recentMatches.filter(isWin).length;
+  const winRate = recentMatches.length > 0 ? Math.round((wins / recentMatches.length) * 100) : 0;
+
+  return (
+    <div className="mx-auto max-w-md">
+      <h2 className="mb-1 text-lg font-bold dark:text-gray-200">Dota 2</h2>
+      <p className="mb-6 text-xs text-gray-500 dark:text-gray-400">
+        minhas estatísticas como melhor jogador do meu prédio
+      </p>
+
+      {/* Perfil */}
+      <motion.div
+        initial={{ opacity: 0, y: 12 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4 }}
+        className="mb-6 flex items-center gap-4 rounded-lg border border-gray-200 p-4 dark:border-gray-700 dark:bg-gray-900"
+      >
+        <a href={profile.profileurl} target="_blank" rel="noopener noreferrer">
+          <motion.div whileHover={{ scale: 1.1 }} whileTap={{ scale: 0.95 }}>
+            <Image
+              src={profile.avatarfull}
+              width={72}
+              height={72}
+              alt={profile.personaname}
+              className="rounded-full"
+              unoptimized
+            />
+          </motion.div>
+        </a>
+
+        <div className="flex-1">
+          <div className="flex items-center gap-2">
+            <p className="font-bold dark:text-gray-100">{profile.personaname}</p>
+            {profile.plus && (
+              <span className="rounded-full bg-yellow-500/20 px-2 py-0.5 text-xs font-semibold text-yellow-400">
+                Plus
+              </span>
+            )}
+          </div>
+          {profile.loccountrycode && (
+            <p className="flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400">
+              <MapPin size={12} />
+              {profile.loccountrycode}
+            </p>
+          )}
+          <a
+            href={profile.profileurl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-1 flex items-center gap-1 text-xs text-gray-400 hover:text-gray-200"
+          >
+            Ver no Steam
+            <ExternalLink size={11} />
+          </a>
+        </div>
+      </motion.div>
+
+      {/* Rank */}
+      {/* {rank && (
+        <motion.div
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.4, delay: 0.1 }}
+          className="mb-6 rounded-lg border border-gray-200 p-4 dark:border-gray-700 dark:bg-gray-900"
+        >
+          <p className="mb-3 text-xs text-gray-500 dark:text-gray-400">Rank</p>
+          <div className="flex items-center gap-3">
+            <Trophy size={28} className={rank.color} />
+            <div>
+              <p className={cn('text-xl font-bold', rank.color)}>{rank.name}</p>
+              {rank.medal < 8 && (
+                <div className="flex gap-0.5">
+                  {Array.from({ length: 5 }).map((_, i) => (
+                    <Star
+                      key={i}
+                      size={12}
+                      className={i < rank.stars ? rank.color : 'text-gray-600'}
+                      fill={i < rank.stars ? 'currentColor' : 'none'}
+                    />
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        </motion.div>
+      )} */}
+
+      {/* Stats */}
+      <motion.div
+        initial={{ opacity: 0, y: 12 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4, delay: 0.2 }}
+        className="mb-6 grid grid-cols-2 gap-3"
+      >
+        {mmr_estimate?.estimate > 0 && <StatCard label="MMR Estimado" value={mmr_estimate.estimate} />}
+        {leaderboard_rank && <StatCard label="Leaderboard" value={`#${leaderboard_rank}`} />}
+        {player.solo_competitive_rank && <StatCard label="Solo MMR" value={player.solo_competitive_rank} />}
+        {player.competitive_rank && <StatCard label="Party MMR" value={player.competitive_rank} />}
+        {recentMatches.length > 0 && (
+          <>
+            <StatCard label="Vitórias (últimas 10)" value={`${wins}W ${recentMatches.length - wins}L`} />
+            <StatCard label="Win Rate" value={`${winRate}%`} />
+          </>
+        )}
+      </motion.div>
+
+      {/* Últimas partidas */}
+      {recentMatches.length > 0 && (
+        <motion.div
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.4, delay: 0.3 }}
+        >
+          <p className="mb-3 text-xs text-gray-500 dark:text-gray-400">Últimas partidas</p>
+          <div className="flex flex-col gap-2">
+            {recentMatches.map((match, i) => (
+              <MatchRow key={match.match_id} match={match} index={i} hero={heroes.get(match.hero_id)} onClick={setSelectedMatch} />
+            ))}
+          </div>
+        </motion.div>
+      )}
+
+      {/* Drawer de detalhes */}
+      <Drawer open={!!selectedMatch} onOpenChange={(open) => !open && setSelectedMatch(null)}>
+        <DrawerContent className="mx-auto flex max-h-[85vh] max-w-md flex-col bg-white dark:bg-black">
+          <DrawerHeader className="flex shrink-0 flex-row items-center justify-between">
+            <DrawerTitle className="text-sm text-gray-500 dark:text-gray-400">
+              #{selectedMatch?.match_id}
+            </DrawerTitle>
+            <DrawerClose asChild>
+              <button className="text-gray-400 hover:text-gray-200">
+                <X size={16} />
+              </button>
+            </DrawerClose>
+          </DrawerHeader>
+
+          <div className="flex-1 overflow-y-auto">
+            {selectedMatch && (
+              <MatchDetail
+                matchId={selectedMatch.match_id}
+                myAccountId={profile.account_id}
+                isWin={isWin(selectedMatch)}
+                heroes={heroes}
+              />
+            )}
+          </div>
+        </DrawerContent>
+      </Drawer>
+    </div>
+  );
+};
+
+export default MyDotaPage;

--- a/src/components/pages/my-dota/use-dota-heroes.ts
+++ b/src/components/pages/my-dota/use-dota-heroes.ts
@@ -1,0 +1,50 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+const STEAM_CDN = 'https://cdn.cloudflare.steamstatic.com';
+
+type HeroStatDto = {
+  id: number;
+  localized_name: string;
+  img: string;
+  icon: string;
+};
+
+export type HeroInfo = {
+  name: string;
+  img: string;
+  icon: string;
+};
+
+export const useDotaHeroes = () => {
+  const [heroes, setHeroes] = useState<Map<number, HeroInfo>>(new Map());
+
+  const loadHeroes = useCallback(() => {
+    fetch('https://api.opendota.com/api/heroStats')
+      .then((res) => {
+        if (!res.ok) throw new Error('Fetch heroStats fail');
+        return res.json() as Promise<HeroStatDto[]>;
+      })
+      .then((data) => {
+        const map = new Map(
+          data.map((h) => [
+            h.id,
+            {
+              name: h.localized_name,
+              img: `${STEAM_CDN}${h.img}`,
+              icon: `${STEAM_CDN}${h.icon}`,
+            },
+          ])
+        );
+        setHeroes(map);
+      })
+      .catch((err) => console.error('error useDotaHeroes', err));
+  }, []);
+
+  useEffect(() => {
+    loadHeroes();
+  }, [loadHeroes]);
+
+  return { heroes };
+};

--- a/src/components/pages/my-dota/use-dota-match.ts
+++ b/src/components/pages/my-dota/use-dota-match.ts
@@ -1,0 +1,72 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export type MatchPlayerDto = {
+  account_id: number | null;
+  player_slot: number;
+  hero_id: number;
+  kills: number;
+  deaths: number;
+  assists: number;
+  last_hits: number;
+  denies: number;
+  gold_per_min: number;
+  xp_per_min: number;
+  net_worth: number;
+  level: number;
+  hero_damage: number;
+  tower_damage: number;
+  hero_healing: number;
+  personaname: string | null;
+  item_0: number;
+  item_1: number;
+  item_2: number;
+  item_3: number;
+  item_4: number;
+  item_5: number;
+};
+
+export type MatchDetailDto = {
+  match_id: number;
+  radiant_win: boolean;
+  duration: number;
+  start_time: number;
+  game_mode: number;
+  radiant_score: number;
+  dire_score: number;
+  patch: number;
+  players: MatchPlayerDto[];
+};
+
+export const useDotaMatch = (matchId: number | null) => {
+  const [match, setMatch] = useState<MatchDetailDto | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadMatch = useCallback(() => {
+    if (!matchId) return;
+
+    setIsLoading(true);
+    setError(null);
+    setMatch(null);
+
+    fetch(`https://api.opendota.com/api/matches/${matchId}`)
+      .then((res) => {
+        if (!res.ok) throw new Error('Fetch match fail');
+        return res.json() as Promise<MatchDetailDto>;
+      })
+      .then((data) => setMatch(data))
+      .catch((err) => {
+        console.error('error useDotaMatch', err);
+        setError('Falha ao carregar detalhes da partida');
+      })
+      .finally(() => setIsLoading(false));
+  }, [matchId]);
+
+  useEffect(() => {
+    loadMatch();
+  }, [loadMatch]);
+
+  return { match, isLoading, error };
+};

--- a/src/components/pages/my-dota/use-dota.ts
+++ b/src/components/pages/my-dota/use-dota.ts
@@ -1,0 +1,89 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export type DotaPlayerDto = {
+  tracked_until: string | null;
+  solo_competitive_rank: number | null;
+  competitive_rank: number | null;
+  rank_tier: number | null;
+  leaderboard_rank: number | null;
+  mmr_estimate: {
+    estimate: number;
+  };
+  profile: {
+    account_id: number;
+    personaname: string;
+    name: string | null;
+    plus: boolean;
+    cheese: number;
+    steamid: string;
+    avatar: string;
+    avatarmedium: string;
+    avatarfull: string;
+    profileurl: string;
+    last_login: string | null;
+    loccountrycode: string | null;
+    is_contributor: boolean;
+    is_subscriber: boolean;
+  };
+};
+
+export type DotaMatchDto = {
+  match_id: number;
+  player_slot: number;
+  radiant_win: boolean;
+  duration: number;
+  game_mode: number;
+  lobby_type: number;
+  hero_id: number;
+  start_time: number;
+  kills: number;
+  deaths: number;
+  assists: number;
+  average_rank: number | null;
+  leaver_status: number;
+  party_size: number | null;
+};
+
+export const useDota = () => {
+  const [player, setPlayer] = useState<DotaPlayerDto>();
+  const [matches, setMatches] = useState<DotaMatchDto[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadData = useCallback(() => {
+    const accountId = process.env.NEXT_PUBLIC_DOTA_ACCOUNT_ID;
+
+    setIsLoading(true);
+    setError(null);
+
+    Promise.all([
+      fetch(`https://api.opendota.com/api/players/${accountId}`).then((res) => {
+        if (!res.ok) throw new Error('Fetch player fail');
+        return res.json() as Promise<DotaPlayerDto>;
+      }),
+      fetch(`https://api.opendota.com/api/players/${accountId}/recentMatches`).then((res) => {
+        if (!res.ok) throw new Error('Fetch matches fail');
+        return res.json() as Promise<DotaMatchDto[]>;
+      }),
+    ])
+      .then(([playerData, matchesData]) => {
+        setPlayer(playerData);
+        setMatches(matchesData);
+      })
+      .catch((err) => {
+        console.error('error useDota', err);
+        setError('Falha ao carregar dados do Dota 2');
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+  }, []);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  return { player, matches, isLoading, error };
+};

--- a/src/components/ui/Navbar.tsx
+++ b/src/components/ui/Navbar.tsx
@@ -6,6 +6,7 @@ import DarkMode from './DarkMode';
 
 const navItems = [
   { path: '/', name: 'home' },
+  { path: '/mydota', name: 'mydota' },
 ];
 
 const tutorialSteps = [

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -153,7 +153,7 @@
     },
     "ui": {
       "footer": { "create_by": "By Matheus Mendes 🗿", "github": "GitHub", "linkedin": "LinkedIn" },
-      "navbar": { "navItems": { "home": "Home", "brain": "Brain" } },
+      "navbar": { "navItems": { "home": "Home", "brain": "Brain", "mydota": "My Dota" } },
       "locale_switcher": { "options": { "en": "English", "pt-br": "Portuguese" } }
     }
   }

--- a/src/messages/pt-br.json
+++ b/src/messages/pt-br.json
@@ -158,7 +158,7 @@
     },
     "ui": {
       "footer": { "create_by": "Criado por Matheus Mendes 🗿", "github": "GitHub", "linkedin": "LinkedIn" },
-      "navbar": { "navItems": { "home": "Inicio", "brain": "Cérebro" } },
+      "navbar": { "navItems": { "home": "Inicio", "brain": "Cérebro", "mydota": "My Dota" } },
       "locale_switcher": { "options": { "en": "Inglês", "pt-br": "Português" } }
     }
   }


### PR DESCRIPTION
- Add /mydota page with player profile, rank, stats and recent matches dashboard
- Fetch player data, recent matches and match details from OpenDota API
- Show hero icons from heroStats endpoint in match list and detail view
- Match detail drawer with team tables (KDA, GPM, XPM, net worth, damage)
- Fix Docker base image from Alpine to Debian slim (glibc/SWC compatibility)
- Update font to Roboto
- Add CLAUDE.md with project architecture docs
- Fix lint errors across my-dota components